### PR TITLE
Skip blank in subwords

### DIFF
--- a/pkg/nemo-asr/src/decode.py
+++ b/pkg/nemo-asr/src/decode.py
@@ -9,6 +9,7 @@ PHONEMIC_BREAK = 0.5
 TOKEN_EOS = {'。', '?', '!'}
 TOKEN_COMMA = {'、', ','}
 TOKEN_PUNC = TOKEN_EOS | TOKEN_COMMA
+SKIP_TOKEN_IDS = {2}
 
 def find_end_of_segment(subwords, start):
     """Heuristics to identify speech boundaries"""
@@ -42,6 +43,8 @@ def decode_hypothesis(model, hyp):
 
     subwords = []
     for idx, (token_id, step) in enumerate(zip(y_sequence, hyp.timestep)):
+        if token_id in SKIP_TOKEN_IDS:  # skip "_" token
+            continue
         subwords.append(Subword(
             token_id=token_id,
             token=model.tokenizer.ids_to_text([token_id]),

--- a/pkg/nemo-asr/src/decode.py
+++ b/pkg/nemo-asr/src/decode.py
@@ -52,7 +52,7 @@ def decode_hypothesis(model, hyp):
             token=model.tokenizer.ids_to_text([token_id]),
             seconds=max(SECONDS_PER_STEP * (step - idx - 1) - PAD_SECONDS, 0)
         ))
-    for idx in skip_indices:
+    for idx in reversed(skip_indices):  # remove "_" tokens
         y_sequence.pop(idx)
 
     segments = []


### PR DESCRIPTION
When there is a blank space at the beginning of the sound source, a  `"_"` subword token is predicted at the beginning.

This can result in cases where silence is included in the predictive segment.

Therefore, I skip the `""` token when recording subwords.

https://github.com/yuta0306/ReazonSpeech/blob/86a4f497db21e53ebddafbe4e438162a7c788d25/pkg/nemo-asr/src/decode.py#L12

```python
subwords = []
skip_indices = []
for idx, (token_id, step) in enumerate(zip(y_sequence, hyp.timestep)):
    if token_id in SKIP_TOKEN_IDS:  # skip "_" token
        skip_indices.append(idx)
        continue
    subwords.append(Subword(
        token_id=token_id,
        token=model.tokenizer.ids_to_text([token_id]),
        seconds=max(SECONDS_PER_STEP * (step - idx - 1) - PAD_SECONDS, 0)
    ))
for idx in reversed(skip_indices):
    y_sequence.pop(idx)
```