### PR TITLE
pipパッケージのバージョン固定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.flac
 *.egg-info
 *.zip
+.vscode/

--- a/pkg/nemo-asr/pyproject.toml
+++ b/pkg/nemo-asr/pyproject.toml
@@ -6,7 +6,9 @@ build-backend = "setuptools.build_meta"
 name = "reazonspeech-nemo-asr"
 version = "2.1.0"
 dependencies = [
-    "numpy",
+    "numpy<2.0.0",
+    "huggingface-hub<=0.23.0",
+    "transformers<=4.33.3",
     "librosa",
     "soundfile",
     "torch",

--- a/pkg/nemo-asr/pyproject.toml
+++ b/pkg/nemo-asr/pyproject.toml
@@ -8,7 +8,6 @@ version = "2.1.0"
 dependencies = [
     "numpy<2.0.0",
     "huggingface-hub<=0.23.0",
-    "transformers<=4.33.3",
     "librosa",
     "soundfile",
     "torch",


### PR DESCRIPTION
こんにちは。
[クイックスタート](https://research.reazon.jp/projects/ReazonSpeech/quickstart.html)に従い実行してみましたが、いくつかのパッケージに互換性が無く実行できなかったため、バージョン指定してみました。
- numpy
  ```
    File "/usr/local/reazonspeech/.venv/lib/python3.10/site-packages/nemo/collections/asr/parts/preprocessing/segment.py", line 168, in _convert_samples_to_float32
      if samples.dtype in np.sctypes['int']:
    File "/usr/local/reazonspeech/.venv/lib/python3.10/site-packages/numpy/__init__.py", line 397, in __getattr__
      raise AttributeError(
  AttributeError: `np.sctypes` was removed in the NumPy 2.0 release. Access dtypes explicitly instead.. Did you mean: 'dtypes'?
  ```
- huggingface-hub
  ```
  from huggingface_hub import HfApi, HfFolder, ModelFilter, hf_hub_download
  ImportError: cannot import name 'ModelFilter' from 'huggingface_hub' (/Users/[省略]/.venv/lib/python3.11/site-packages/huggingface_hub/__init__.py)
  ```
もしお時間あればお手元で確かめて頂けますでしょうか。
また、実行前に`setuptools`と`wheel`もupdateする必要がありました。