### PR TITLE
Pin nemo_toolkit[asr] version to below 2.2

### DIFF
--- a/pkg/nemo-asr/pyproject.toml
+++ b/pkg/nemo-asr/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "librosa",
     "soundfile",
     "torch",
-    "nemo_toolkit[asr]",
+    "nemo_toolkit[asr] < 2.2",
 ]
 
 [tool.setuptools.package-dir]


### PR DESCRIPTION
To fix an error with nemo_toolkit 2.2.0.
`AttributeError: 'Hypothesis' object has no attribute 'timestep'`

This resolves the issue #46