### PR TITLE
Add resume_download=True parameter to model loading functions

### DIFF
--- a/pkg/_v1/src/transcribe.py
+++ b/pkg/_v1/src/transcribe.py
@@ -124,7 +124,8 @@ def load_default_model():
         ctc_weight=0.3,
         lm_weight=0.3,
         beam_size=20,
-        device=device)
+        device=device,
+        resume_download=True)
 
 def transcribe(audio, speech2text=None, config=None):
     """Interface function to transcribe audio data

--- a/pkg/k2-asr/src/huggingface.py
+++ b/pkg/k2-asr/src/huggingface.py
@@ -63,9 +63,9 @@ def load_model(device="cpu", precision="fp32", language="ja"):
     # If the model is found in the local cache, do not connect
     # to Hugging Face.
     try:
-        basedir = hf.snapshot_download(hf_repo_id, local_files_only=True)
+        basedir = hf.snapshot_download(hf_repo_id, local_files_only=True, resume_download=True)
     except hf.utils.LocalEntryNotFoundError:
-        basedir = hf.snapshot_download(hf_repo_id)
+        basedir = hf.snapshot_download(hf_repo_id, resume_download=True)
 
     return sherpa_onnx.OfflineRecognizer.from_transducer(
         tokens=os.path.join(basedir, files["tokens"]),

--- a/pkg/nemo-asr/src/transcribe.py
+++ b/pkg/nemo-asr/src/transcribe.py
@@ -25,7 +25,8 @@ def load_model(device=None):
     logging.setLevel(logging.ERROR)
     from nemo.collections.asr.models import EncDecRNNTBPEModel
     return EncDecRNNTBPEModel.from_pretrained('reazon-research/reazonspeech-nemo-v2',
-                                              map_location=device)
+                                              map_location=device,
+                                              resume_download=True)
 
 def transcribe(model, audio, config=None):
     """Inference audio data using NeMo model


### PR DESCRIPTION
I've added the `resume_download=True` parameter to model loading functions across our ASR packages. This enhancement enables interrupted model downloads to resume from where they left off instead of starting over from scratch.

## Changes Made

- Added `resume_download=True` to the default model loader in `pkg/_v1/src/transcribe.py`
- Added it to the NeMo model loading function in `pkg/nemo-asr/src/transcribe.py`
- Added the parameter to both local and remote Hugging Face downloads in `pkg/k2-asr/src/huggingface.py`

## Motivation

When downloading large speech recognition models, network interruptions can cause the entire download to fail and restart. This change improves reliability and user experience by allowing downloads to resume from the point of interruption.