### PR TITLE
Remove resume_download argument on loading a NeMo model

### DIFF
--- a/pkg/_v1/src/transcribe.py
+++ b/pkg/_v1/src/transcribe.py
@@ -124,8 +124,7 @@ def load_default_model():
         ctc_weight=0.3,
         lm_weight=0.3,
         beam_size=20,
-        device=device,
-        resume_download=True)
+        device=device)
 
 def transcribe(audio, speech2text=None, config=None):
     """Interface function to transcribe audio data

--- a/pkg/k2-asr/src/huggingface.py
+++ b/pkg/k2-asr/src/huggingface.py
@@ -63,9 +63,9 @@ def load_model(device="cpu", precision="fp32", language="ja"):
     # If the model is found in the local cache, do not connect
     # to Hugging Face.
     try:
-        basedir = hf.snapshot_download(hf_repo_id, local_files_only=True, resume_download=True)
+        basedir = hf.snapshot_download(hf_repo_id, local_files_only=True)
     except hf.utils.LocalEntryNotFoundError:
-        basedir = hf.snapshot_download(hf_repo_id, resume_download=True)
+        basedir = hf.snapshot_download(hf_repo_id)
 
     return sherpa_onnx.OfflineRecognizer.from_transducer(
         tokens=os.path.join(basedir, files["tokens"]),

--- a/pkg/nemo-asr/src/transcribe.py
+++ b/pkg/nemo-asr/src/transcribe.py
@@ -25,8 +25,7 @@ def load_model(device=None):
     logging.setLevel(logging.ERROR)
     from nemo.collections.asr.models import EncDecRNNTBPEModel
     return EncDecRNNTBPEModel.from_pretrained('reazon-research/reazonspeech-nemo-v2',
-                                              map_location=device,
-                                              resume_download=True)
+                                              map_location=device)
 
 def transcribe(model, audio, config=None):
     """Inference audio data using NeMo model


### PR DESCRIPTION
This pull request removes `resume_download` flag on loading models on Hugging Face Hub library.

This resolves #55.
