### PR TITLE
Skip num2words when output has string of too large number

### DIFF
--- a/pkg/evaluation/src/utils.py
+++ b/pkg/evaluation/src/utils.py
@@ -19,8 +19,11 @@ ZEN2HAN = str.maketrans(ZENKAKU, HANKAKU)
 
 def normalize(s: str) -> str:
     s = s.translate(PUNCTUATIONS).translate(ZEN2HAN)
-    conv = lambda m: num2words.num2words(m.group(0), lang="ja")
-    return re.sub(r"\d+\.?\d*", conv, s)
+    try:
+        conv = lambda m: num2words.num2words(m.group(0), lang="ja")
+        return re.sub(r"\d+\.?\d*", conv, s)
+    except OverflowError:
+        return s
 
 
 def calculate_cer(reference: str, prediction: str) -> CERResult:


### PR DESCRIPTION
## Issue

If the model output has too large a number caused by repetition or hallucination, conversion with num2words would raise `OverflowError`.

```
    raise OverflowError(self.errmsg_toobig % (value, self.MAXVAL))
OverflowError: abs(1212121212121212121212121212121212121212121212121212121212121212121212121212121212121212121212121212121212121211) must be less than 1000000000000000000000000000000000000000000000000000.
```