### PR TITLE
Refactor transcribe: Support in-memory audio input and remove temporary file I/O

### DIFF
--- a/pkg/nemo-asr/src/transcribe.py
+++ b/pkg/nemo-asr/src/transcribe.py
@@ -43,7 +43,7 @@ def transcribe(model, audio, config=None):
 
     audio = pad_audio(norm_audio(audio), PAD_SECONDS)
 
-    waveform_tensor = torch.tensor(audio.waveform, dtype=torch.float32)
+    waveform_tensor = torch.from_numpy(audio.waveform)
 
     result = model.transcribe(
         [waveform_tensor],

--- a/pkg/nemo-asr/src/transcribe.py
+++ b/pkg/nemo-asr/src/transcribe.py
@@ -43,22 +43,15 @@ def transcribe(model, audio, config=None):
 
     audio = pad_audio(norm_audio(audio), PAD_SECONDS)
 
-    # TODO Study NeMo's transcribe() function and make it
-    # possible to pass waveforms on memory.
-    with create_tempfile() as tmpf:
-        audio_to_file(tmpf, audio)
+    waveform_tensor = torch.tensor(audio.waveform, dtype=torch.float32)
 
-        if os.name == 'nt':
-            tmpf.close()
-
-        result = model.transcribe(
-            [tmpf.name],
-            batch_size=1,
-            return_hypotheses=True,
-            verbose=config.verbose
-        )
-        hyp = result[0]
-
+    result = model.transcribe(
+        [waveform_tensor],
+        batch_size=1,
+        return_hypotheses=True,
+        verbose=config.verbose
+    )
+    hyp = result[0]
     ret = decode_hypothesis(model, hyp)
 
     if config.raw_hypothesis:


### PR DESCRIPTION
**Changes**
According to the NVIDIA NeMo documentation, the `model.transcribe()` method natively supports `numpy.ndarray` or `torch.Tensor` as input. This PR refactors the inference pipeline to leverage this feature:

*   **Direct Memory Access**: The `AudioData` waveform is now converted directly to a `torch.Tensor` and passed to the model, bypassing the file system entirely.
*   **Removed I/O Dependencies**: Removed calls to `fs.create_tempfile` and `audio_to_file` within the `transcribe` function.
*   **Code Cleanup**: Simplified the logic in `transcribe.py`.

**Reference**
Passing tensors directly to the model is a supported pattern and can be seen in other implementations as well:
https://github.com/wjz2001/ReazonSpeech/blob/b62b8fe04bdaa9de50a2bea503e93f99e1e7f151/asr.py#L797